### PR TITLE
Add collision filter data to demo

### DIFF
--- a/examples/browser-three/package.json
+++ b/examples/browser-three/package.json
@@ -18,7 +18,7 @@
     "webpack-dev-server": "^3.10.1"
   },
   "dependencies": {
-    "physx-js": "^0.0.6",
+    "physx-js": "^0.3.0",
     "three": "^0.112.1"
   }
 }

--- a/examples/browser-three/src/physics.js
+++ b/examples/browser-three/src/physics.js
@@ -83,6 +83,11 @@ export const init = entities => {
         PhysX.PxShapeFlag.eSIMULATION_SHAPE.value
     )
     const shape = physics.createShape(geometry, material, false, flags)
+    
+    const filterData = new PhysX.PxFilterData(1, 1, 0, 0)
+    shape.setQueryFilterData(filterData)
+    shape.setSimulationFilterData(filterData)
+    
     const transform = {
       translation: {
         x: entity.transform.position[0],


### PR DESCRIPTION
It took me a fair amount of digging to find out that the latest version of the npm package uses the `LayerMaskFilterShader` by default. It might be helpful to add it to the demo. 
(See also, Issue #6)